### PR TITLE
Unity Constants generator enhancements

### DIFF
--- a/UnityConstants/Editor/UnityConstantsGenerator.cs
+++ b/UnityConstants/Editor/UnityConstantsGenerator.cs
@@ -67,16 +67,26 @@ namespace UnityToolbag
                 writer.WriteLine("        // Regular layer indices for assigning layers dynamically in code");
                 for (int i = 0; i < 32; i++) {
                     string layer = UnityEditorInternal.InternalEditorUtility.GetLayerName(i);
-                    if (!string.IsNullOrEmpty(layer)) {
-                        writer.WriteLine("        public const int {0} = {1};", MakeSafeForCode(layer), i);
+                    if (!string.IsNullOrEmpty(layer))
+                    {
+	                    string layerName = MakeSafeForCode(layer);
+						writer.WriteLine("        /// <summary>");
+						writer.WriteLine("        /// Index of layer {0}", layerName);
+						writer.WriteLine("        /// </summary>");
+                        writer.WriteLine("        public const int {0} = {1};", layerName, i);
                     }
                 }
                 writer.WriteLine();
                 writer.WriteLine("        // Pre-configured layer masks for use with raycasts or other such queries");
                 for (int i = 0; i < 32; i++) {
                     string layer = UnityEditorInternal.InternalEditorUtility.GetLayerName(i);
-                    if (!string.IsNullOrEmpty(layer)) {
-                        writer.WriteLine("        public const int {0}Mask = {1};", MakeSafeForCode(layer), 1 << i);
+					if (!string.IsNullOrEmpty(layer))
+					{
+						string layerName = MakeSafeForCode(layer);
+						writer.WriteLine("        /// <summary>");
+						writer.WriteLine("        /// Bitmask of layer {0}", layerName);
+						writer.WriteLine("        /// </summary>");
+                        writer.WriteLine("        public const int {0}Mask = {1};", layerName, 1 << i);
                     }
                 }
                 writer.WriteLine("    }");

--- a/UnityConstants/Editor/UnityConstantsGenerator.cs
+++ b/UnityConstants/Editor/UnityConstantsGenerator.cs
@@ -86,7 +86,7 @@ namespace UnityToolbag
 						writer.WriteLine("        /// <summary>");
 						writer.WriteLine("        /// Bitmask of layer {0}", layerName);
 						writer.WriteLine("        /// </summary>");
-                        writer.WriteLine("        public const int {0}Mask = {1};", layerName, 1 << i);
+                        writer.WriteLine("        public const int {0}Mask = 1 << {1};", layerName, i);
                     }
                 }
                 writer.WriteLine("    }");

--- a/UnityConstants/Editor/UnityConstantsGenerator.cs
+++ b/UnityConstants/Editor/UnityConstantsGenerator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -75,7 +76,7 @@ namespace UnityToolbag
                 for (int i = 0; i < 32; i++) {
                     string layer = UnityEditorInternal.InternalEditorUtility.GetLayerName(i);
                     if (!string.IsNullOrEmpty(layer)) {
-                        writer.WriteLine("        public const int {0}Mask = 1 << {0};", MakeSafeForCode(layer));
+                        writer.WriteLine("        public const int {0}Mask = {1};", MakeSafeForCode(layer), 1 << i);
                     }
                 }
                 writer.WriteLine("    }");
@@ -103,7 +104,7 @@ namespace UnityToolbag
         // if the string starts with a number. It's not the most robust, but should handle most cases just fine.
         private static string MakeSafeForCode(string str)
         {
-            str = str.Replace(" ", "");
+			str = Regex.Replace(str, "[^a-zA-Z0-9_.]+", "", RegexOptions.Compiled);
             if (char.IsDigit(str[0])) {
                 str = "_" + str;
             }


### PR DESCRIPTION
The MakeSafeForCode function currently does not handle dashes inside the layer names, a regex to strip all special characters from layer names makes it more robust.

Added comments to the Layer incides/bitmasks that show up in intellisense.