### PR TITLE
Switched the obsolete window.title to use window.titleContent.text

### DIFF
--- a/EditorTools/Editor.meta
+++ b/EditorTools/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8877a57c27de55441bd28ae97fa2a3d7
+folderAsset: yes
+timeCreated: 1441260689
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SnapToSurface/Editor/SnapToSurface.cs
+++ b/SnapToSurface/Editor/SnapToSurface.cs
@@ -36,7 +36,7 @@ namespace UnityToolbag
         static void ShowWindow()
         {
             var window = EditorWindow.GetWindow<SnapToSurface>();
-            window.title = "Snap To Surface";
+            window.titleContent.text = "Snap To Surface";
         }
 
         static void Drop(Vector3 dir)


### PR DESCRIPTION
Unity was complaining that window.title was obsolete and to use window.titleContent instead, I tested it briefly after making the change and haven't encountered any errors or problems as a result of this.

Hopefully you can use this :+1: 