### PR TITLE
Added ResourcePathAttribute

### DIFF
--- a/ResourcePathAttribute/Editor/ResourcePathDrawer.cs
+++ b/ResourcePathAttribute/Editor/ResourcePathDrawer.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using UnityEngine;
+using UnityEditor;
+using System.Collections;
+using Object = UnityEngine.Object;
+
+namespace UnityToolbag
+{
+	[CustomPropertyDrawer(typeof(ResourcePathAttribute))]
+	public class ResourcePathDrawer : PropertyDrawer
+	{
+		private const double flashTime = 0.25f;
+		private static readonly Color flashColor = new Color(0.9f, 0f, 0f, 1f);
+
+		private double flashStarted = -1d;
+		private float flashAlpha = 0f;
+
+		private SerializedProperty targetProp = null;
+
+		public static bool TryGetResourcePath(string assetPath, out string resourcePath)
+		{
+			resourcePath = "";
+
+			string[] pathSections = assetPath.Split(new string[] { "Resources/" }, StringSplitOptions.None);
+			if (pathSections.Length != 2)
+				return false;
+
+			resourcePath = pathSections[1];
+			resourcePath = resourcePath.Substring(0, resourcePath.LastIndexOf('.'));
+
+			return true;
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			// Reject drawing this custom attribute if property wasn't a string type
+			if (property.propertyType != SerializedPropertyType.String)
+			{
+				EditorGUI.PropertyField(position, property, label);
+				return;
+			}
+
+			ResourcePathAttribute pathAttribute = (ResourcePathAttribute) attribute;
+
+			// Can't get attribute for some reason
+			if (pathAttribute == null)
+			{
+				EditorGUI.PropertyField(position, property, label);
+				return;
+			}
+
+			if (flashAlpha > 0 && SerializedProperty.EqualContents(targetProp, property))
+			{
+				EditorGUI.DrawRect(position, new Color(flashColor.r, flashColor.g, flashColor.b, flashAlpha));
+			}
+
+			Object resourceObject = Resources.Load(property.stringValue);
+			Object newObject = EditorGUI.ObjectField(position, label, resourceObject, pathAttribute.allowedType, false);
+
+			if (resourceObject == newObject)
+				return;
+
+			if (pathAttribute.allowedType != null && newObject != null)
+			{
+				bool isCorrectType = newObject.GetType() == pathAttribute.allowedType;
+				if (isCorrectType == false)
+					return;
+			}
+
+			// Object is null, empty the string value
+			if (newObject == null)
+			{
+				property.stringValue = "";
+				property.serializedObject.ApplyModifiedProperties();
+			}
+			else
+			{
+				string fullPath = AssetDatabase.GetAssetPath(newObject);
+				string resourcePath;
+				if (TryGetResourcePath(fullPath, out resourcePath))
+				{
+					property.stringValue = resourcePath;
+					property.serializedObject.ApplyModifiedProperties();
+				}
+				else // Not a resource object, flash the inspector
+				{
+					flashStarted = EditorApplication.timeSinceStartup;
+					targetProp = property;
+
+					EditorApplication.update += FlashInspector;
+				}
+			}
+		}
+
+		private void StartInspectorFlash()
+		{
+			
+		}
+
+		private void FlashInspector()
+		{
+			double passedTime = EditorApplication.timeSinceStartup - flashStarted;
+			double t = passedTime/flashTime;
+
+			if (t > 1f)
+			{
+				EditorApplication.update -= FlashInspector;
+				flashAlpha = 0f;
+				flashStarted = -1d;
+				targetProp = null;
+			}
+			else
+			{
+				flashAlpha = 1 - Convert.ToSingle(t);
+				EditorUtility.SetDirty(targetProp.serializedObject.targetObject);
+			}
+		}
+	}
+}

--- a/ResourcePathAttribute/README.md
+++ b/ResourcePathAttribute/README.md
@@ -1,0 +1,20 @@
+Resource Path Attribute
+===
+
+Turns a string property into an Object Field in the inspector which only accepts objects from Resource paths. Helps keep config file loading from getting bloated when referencing large files.
+
+Usage
+---
+
+```C#
+public class ExampleConfig : ScriptableObject
+{
+  // An object field that accepts generic objects
+  [ResourcePath]
+  public string prefabPath;
+
+  // An object field that only accepts AudioClip objects
+  [ResourcePath(typeof(AudioClip))]
+  public string audioPath;
+}
+```

--- a/ResourcePathAttribute/ResourcePathAttribute.cs
+++ b/ResourcePathAttribute/ResourcePathAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UnityEngine;
+
+namespace UnityToolbag
+{
+	public class ResourcePathAttribute : PropertyAttribute
+	{
+		public Type allowedType;
+
+		/// <summary>
+		/// Show string as an object box that points to a resource asset.
+		/// </summary>
+		public ResourcePathAttribute()
+		{
+			allowedType = null;
+		}
+
+		/// <summary>
+		/// Show string as an object box that points to a resource asset, restricted by a type
+		/// </summary>
+		/// <param name="restrictType">Type of asset that can be placed into object box.</param>
+		public ResourcePathAttribute(Type restrictType)
+		{
+			allowedType = restrictType;
+		}
+	}
+}


### PR DESCRIPTION
Resource path attribute turns strings properties into object fields in the inspector that will only take objects from Resource folders. Useful for making ScriptableObjects use a path reference instead of a direct object reference which can cause longer load times when using the ScriptableObject.