### PR TITLE
Removing unused using directive supported in 5.3+

### DIFF
--- a/UnityConstants/Editor/UnityConstantsGenerator.cs
+++ b/UnityConstants/Editor/UnityConstantsGenerator.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using UnityEditor;
 using System.IO;
 using System.Collections.Generic;
-using UnityEngine.SceneManagement;
 
 namespace UnityToolbag
 {


### PR DESCRIPTION
This way the script works with Unity 5.2 and less.